### PR TITLE
Moved all discount calculations to item-level, using orders__line_ite…

### DIFF
--- a/models/aggregates/shopify_order_aggregates.sql
+++ b/models/aggregates/shopify_order_aggregates.sql
@@ -6,6 +6,7 @@ select
 	sum(quantity) as count_of_items,
 	sum(line_item_net_sales) as net_sales,
 	sum(line_item_gross_sales) as gross_sales,
+	sum(line_item_discount) as order_discount,
 	sum(line_item_weight) as weight,
 	max(updated_at) as updated_at
 

--- a/models/aggregates/shopify_order_discounts.sql
+++ b/models/aggregates/shopify_order_discounts.sql
@@ -4,7 +4,6 @@ select
 	listagg(code, ', ') within group (order by code) as codes_used,
 	sum(amount) as amount,
 	sum(case when type = 'shipping' then amount end) as freight_discount,
-	sum(case when type != 'shipping' then amount end) as order_discount,
 	max(updated_at) as updated_at
 
 

--- a/models/aggregates/shopify_order_item_discounts.sql
+++ b/models/aggregates/shopify_order_item_discounts.sql
@@ -1,0 +1,9 @@
+select
+
+	order_id,
+	line_item_number,
+
+	sum(amount) as line_item_discount
+
+from {{ref('shopify_base_order_item_discount_allocations')}}
+group by 1, 2

--- a/models/base/shopify_base_order_item_discount_allocations.sql
+++ b/models/base/shopify_base_order_item_discount_allocations.sql
@@ -1,0 +1,9 @@
+--Contains details on discounts applied at the line_item level
+
+select
+
+  _sdc_source_key_id as order_id,
+  _sdc_level_0_id as line_item_number,
+  amount
+
+from {{source('stitch_shopify', 'orders__line_items__discount_allocations')}}

--- a/models/base/shopify_base_order_items.sql
+++ b/models/base/shopify_base_order_items.sql
@@ -18,15 +18,14 @@ select
   oi.price,
   pv.compare_at_price,
   oi.quantity,
-  oi.total_discount as line_item_discount,
-  (oi.price * oi.quantity) - oi.total_discount as line_item_net_sales,
+  oid.line_item_discount,
+  (oi.price * oi.quantity) - nvl(oid.line_item_discount,0) as line_item_net_sales,
   (oi.price * oi.quantity) as line_item_gross_sales,
   pv.weight,
   pv.weight_unit,
   pv.weight * oi.quantity as line_item_weight,
   ri.refunded_quantity,
   ri.refunded_subtotal,
-
     
 --Timestamps
   greatest(oi.updated_at, p.updated_at, pv.updated_at) as updated_at,
@@ -38,3 +37,4 @@ from {{ref('shopify_source_order_items')}} oi
 left join {{ref('shopify_source_products')}} p on p.id = oi.product_id
 left join {{ref('shopify_source_product_variants')}} pv on pv.id = oi.variant_id
 left join {{ref('shopify_source_refund_items')}} ri on oi.id = ri.line_item_id
+left join {{ref('shopify_order_item_discounts')}} oid using(order_id, line_item_number)

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -32,6 +32,8 @@ sources:
       description: https://shopify.dev/docs/admin-api/rest/reference/orders/order
     - name: orders__line_items__properties
       description: https://shopify.dev/docs/admin-api/rest/reference/orders/order
+    - name: orders__line_items__discount_allocations
+      description: https://shopify.dev/docs/admin-api/rest/reference/orders/order
     - name: orders__fulfillments
       description: https://shopify.dev/docs/admin-api/rest/reference/orders/order
     - name: orders__shipping_lines

--- a/models/tables/shopify_order_items.sql
+++ b/models/tables/shopify_order_items.sql
@@ -33,6 +33,7 @@ select
   o.customer_order_number,    
   o.net_sales as order_net_sales,
   o.gross_sales as order_gross_sales,
+
 --Timestamps
   o.created_at,
   o.cancelled_at,

--- a/models/tables/shopify_orders.sql
+++ b/models/tables/shopify_orders.sql
@@ -48,8 +48,8 @@ select
   oda.discount_type as discount_type,
   oda.discount_title as discount_title,
   substring(od.codes_used,0,1024) as codes_used,
-  od.amount as discounts,
-  od.order_discount,
+  od.amount as discounts,  -- To be deprecated. oa.order_discount now includes all discounts, except for freight discounts
+  oa.order_discount,
   od.freight_discount,
 
 --Calculated Columns


### PR DESCRIPTION
…ms__discount_allocations table

DO NOT MERGE UNTIL WE CLEAN UP DTC DATA SOURCES IN TABLEAU. 

This PR results in changes to the way discount amounts are attributed. Whereas before discounts were a combination of line-time discounts and order-level coupon amounts re-distributed at the item level, now all discounts are calculated at the item level. 

Once this is merged we will need to update any remaining DTC data sources to only use the item-level discount amount, to avoid double-counting.