### PR TITLE
Recategorized sub and save discount from manual to automatic

### DIFF
--- a/models/tables/shopify_orders.sql
+++ b/models/tables/shopify_orders.sql
@@ -45,8 +45,14 @@ select
   oa.gross_sales,
   oa.weight,
   o.shipping_price,
-  oda.discount_type as discount_type,
-  oda.discount_title as discount_title,
+  case 
+    when o.source = 'ordergroove' and oda.discount_type = 'manual' and oda.discount_title = 'Item Discount' then 'automatic'
+    else oda.discount_type
+  end as discount_type,
+  case 
+    when o.source = 'ordergroove' and oda.discount_type = 'manual' and oda.discount_title = 'Item Discount' then 'Subscribe & Save'
+    else oda.discount_title
+  end as discount_title,  
   substring(od.codes_used,0,1024) as codes_used,
   od.amount as discounts,  -- To be deprecated. oa.order_discount now includes all discounts, except for freight discounts
   oa.order_discount,


### PR DESCRIPTION
We started offering a subscribe and save discount of 10-25% for orders fulfilled through ordergroove. When ordergroove sends this discount information back to Shopify, it gets classified as:

discount_type = manual
discount_title = Item Discount

This PR recategorizes all orders from a source of ordergroove with the above discount information as an automatic discount, with a title of 'Subscribe & Save'