### PR TITLE
Updated how subscription and prepaid orders are identified

### DIFF
--- a/models/base/shopify_base_orders.sql
+++ b/models/base/shopify_base_orders.sql
@@ -22,15 +22,17 @@ select
     when lower(tags) like '%giftwizard%' then TRUE
     else FALSE
   end as gift_order,
-  lower(tags) like '%ordergroove prepaid order%' as is_prepaid_subscription, 
+  lower(tags) like '%ordergroove prepaid order%' or lower(tags) like '%prepaid fulfillment order%' as is_prepaid_subscription, 
   case 
-    when is_prepaid_subscription or source_name = 'subscription_contract' then 'ordergroove'
+    when is_prepaid_subscription 
+      or lower(tags) like '%ordergroove subscription order%' 
+      or lower(tags) like '%ordergroove trigger order%' 
+      then 'ordergroove'
     when source_name = 'web' then 'web'
     when source_name = '294517' then 'recharge'
     when source_name = 'Giftwizard' then 'giftwizard'
     else 'other'
   end as source,
-
   shipping_address_1,
   shipping_address_2,
   shipping_name,


### PR DESCRIPTION
We were not properly identifying all prepaid and subscription orders. Updated logic to capture all possible ordergroove tags.

Here are the expected impacts:

https://docs.google.com/spreadsheets/d/14Kju9Lx8AAmo4ehqETaSXc3tXcwY5Yp8xOcWBTYYoX8/edit#gid=932266391
